### PR TITLE
fix(strength_estimator): export password strength estimator

### DIFF
--- a/lib/password_engine.dart
+++ b/lib/password_engine.dart
@@ -14,6 +14,7 @@ export 'src/model/password_generation_exception.dart';
 export 'src/model/password_strength.dart';
 export 'src/strategy/ipassword_generation_strategy.dart';
 export 'src/strategy/random_password_strategy.dart';
+export 'src/strength_estimator/ipassword_strength_estimator.dart';
 export 'src/strength_estimator/password_strength_estimator.dart';
 export 'src/validator/ipassword_validator.dart';
 export 'src/validator/password_validator.dart';


### PR DESCRIPTION
## Description

This PR exports the `IPasswordStrengthEstimator` class to allow developers to create customized password strength estimators based on their specific requirements.

## Changes

- Exported `PasswordStrengthEstimator` from the library's public API
- Enables users to instantiate and configure custom password strength estimation logic

## Motivation

Previously, the password strength estimator was not accessible to external consumers of the library. By exporting this class, developers can now:

- Create custom instances with tailored strength calculation rules
- Extend the estimator to meet specific security requirements
- Integrate password strength validation into their applications with custom configurations

## Usage Example

```dart
import 'package:password_engine/password_engine.dart';

class ExampleZxcvbnStrengthEstimator implements IPasswordStrengthEstimator {
  ExampleZxcvbnStrengthEstimator({List<String> userInputs = const []})
      : _userInputs = List.unmodifiable(userInputs),
        _zxcvbn = Zxcvbn();

  final List<String> _userInputs;
  final Zxcvbn _zxcvbn;

  @override
  PasswordStrength estimatePasswordStrength(String password) {
    if (password.isEmpty) return PasswordStrength.veryWeak;

    final result = _zxcvbn.evaluate(password, userInputs: _userInputs);
    final score = (result.score ?? 0).round().clamp(0, 4).toInt();
    return mapScoreToStrength(score);
  }
}
```