### PR TITLE
chore: Exclude generated i18n files from analyzer

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:lints/recommended.yaml
 
+analyzer:
+  exclude:
+    - "lib/l10n/*.i18n.dart"
+    -
 linter:
   rules:
     prefer_single_quotes: true


### PR DESCRIPTION
Fixes the analysis warnings for unused variables in generated i18n files by excluding them from static analysis in `analysis_options.yaml`.