### PR TITLE
fix(ci): add --no-example flag to dart pub get in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ jobs:
           sdk: stable
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get --no-example
 
       - name: Verify publishing eligibility
         run: dart pub publish --dry-run


### PR DESCRIPTION
## Summary

Fixes the `publish.yaml` CI workflow by adding the `--no-example` flag to the `dart pub get` step, preventing it from resolving dependencies for the example project during the publishing pipeline.

## Changes

- **`.github/workflows/publish.yaml`**: Updated the `Install dependencies` step from `dart pub get` to `dart pub get --no-example`.

## Why

The example project may have Flutter-specific dependencies that are not resolvable in a pure Dart SDK environment. Since the publish workflow only needs the library's own dependencies, skipping example resolution avoids unnecessary failures.