### PR TITLE
fix(utils): use Set for containsAnyOf character check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1
+
+- **Fix**: Make character set lookup faster in `containsAnyOf`.
+  - Used a Set of runes instead of checking characters linearly.
+  - Added unit tests for empty inputs, mismatches, and Unicode characters.
+
 ## 1.0.0
 
 - Initial release of `password_engine`.

--- a/lib/src/utils/password_string_extensions.dart
+++ b/lib/src/utils/password_string_extensions.dart
@@ -29,8 +29,9 @@ extension PasswordStringX on String {
   /// Uses a [Set] for O(1) lookup per character instead of O(m) string search.
   bool containsAnyOf(String charSet) {
     if (charSet.isEmpty) return false;
-    for (var i = 0; i < length; i++) {
-      if (charSet.contains(this[i])) return true;
+    final set = charSet.runes.toSet();
+    for (final rune in runes) {
+      if (set.contains(rune)) return true;
     }
     return false;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: password_engine
 description: "A comprehensive and extensible password generation library for Dart and Flutter"
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/dhruvanbhalara/password_engine
 repository: https://github.com/dhruvanbhalara/password_engine
 issue_tracker: https://github.com/dhruvanbhalara/password_engine/issues

--- a/test/utils/password_string_extensions_test.dart
+++ b/test/utils/password_string_extensions_test.dart
@@ -45,5 +45,24 @@ void main() {
       expect(''.hasUnicode, isFalse);
       expect(('a' * 1000 + '\u03C0').hasUnicode, isTrue);
     });
+
+    group('containsAnyOf', () {
+      test('returns false on empty charset pool', () {
+        expect('abc'.containsAnyOf(''), isFalse);
+      });
+
+      test('returns false when no characters match', () {
+        expect('abc'.containsAnyOf('xyz'), isFalse);
+      });
+
+      test('returns true when character matches', () {
+        expect('abc'.containsAnyOf('cxz'), isTrue);
+      });
+
+      test('handles unicode characters correctly', () {
+        expect('abc\u{1F60A}'.containsAnyOf('\u{1F60A}'), isTrue);
+        expect('abc\u{1F60A}'.containsAnyOf('\u{1F60B}'), isFalse);
+      });
+    });
   });
 }


### PR DESCRIPTION
Use Set-based lookup in the containsAnyOf string extension.

Currently, containsAnyOf uses a linear search on the input character pool string. For long strings and character lists, this can slow down performance. The documentation comment also states that a Set is used for O(1) character lookup, which was not the case in the implementation.

This change converts the input character pool to a Set of runes and searches the target string's runes against it. We also add test cases to test/utils/password_string_extensions_test.dart to verify correct lookup behavior.